### PR TITLE
Features/infinite scroll

### DIFF
--- a/CHCarouselView/Base.lproj/Main.storyboard
+++ b/CHCarouselView/Base.lproj/Main.storyboard
@@ -24,6 +24,9 @@
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="aGf-mm-11t" secondAttribute="height" multiplier="375:300" id="2ql-GM-bdD"/>
                                 </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isInfinite" value="YES"/>
+                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <outlet property="pageControl" destination="dao-0h-dFR" id="62C-gz-QZB"/>
                                 </connections>

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -78,13 +78,11 @@ public class CarouselView: UIScrollView {
     }
     
     override public func drawRect(rect: CGRect) {
+        resetInfiniteContentShift()
+        
         views
-            .enumerate()
-            .forEach { (index: Int, view: UIView) in
-                let viewOffset = CGPoint(x: CGFloat(index) * self.bounds.width, y: 0)
-                view.frame = CGRect(origin: viewOffset, size: self.bounds.size)
-            
-                self.addSubview(view)
+            .forEach {
+                self.addSubview($0)
             }
         
         pageControl?.numberOfPages = views.count

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -148,6 +148,22 @@ public class CarouselView: UIScrollView {
                 view.frame = CGRect(origin: viewOffset, size: self.bounds.size)
             }
     }
+    
+    private func shiftToRealViewPosition() {
+        let viewsCount = CGFloat(views.count)
+        
+        if self.contentOffset.x <= 0 {
+            self.contentOffset = CGPoint(x: viewsCount * self.bounds.size.width, y: 0)
+            
+            resetInfiniteContentShift()
+            
+        } else if self.contentOffset.x >= (viewsCount + 1) * self.bounds.size.width {
+            self.contentOffset = CGPointMake(self.bounds.size.width, 0)
+            
+            resetInfiniteContentShift()
+        }
+
+    }
 }
 
 // MARK: - ScrollViewDelegate

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -133,6 +133,16 @@ public class CarouselView: UIScrollView {
             break
         }
     }
+    
+    private func resetInfiniteContentShift() {
+        views
+            .enumerate()
+            .forEach { (index: Int, view: UIView) in
+                let indexShiftted = isInfinite ? index + 1 : index
+                let viewOffset = CGPoint(x: CGFloat(indexShiftted) * self.bounds.width, y: 0)
+                view.frame = CGRect(origin: viewOffset, size: self.bounds.size)
+            }
+    }
 }
 
 // MARK: - ScrollViewDelegate

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -94,7 +94,15 @@ public class CarouselView: UIScrollView {
     
     // MARK: - KVO Delegate
     override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
-        if keyPath == "contentOffset" {
+        
+        if keyPath == "contentOffset" && isInfinite {
+            guard let change = change, let oldOffset = change[NSKeyValueChangeOldKey] as? CGPoint else {
+                return
+            }
+            
+            let newOffset = self.contentOffset
+            
+            prepareViewForInfiniteInlusion(ScrollDirection(fromPoint: oldOffset, toPoint: newOffset))
             
         } else {
             super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
@@ -110,6 +118,10 @@ public class CarouselView: UIScrollView {
         self.scrollsToTop = false
         
         self.addObserver(self, forKeyPath: "contentOffset", options: .Old, context: nil)
+    }
+    
+    private func prepareViewForInfiniteInlusion(direction: ScrollDirection) {
+        
     }
 }
 

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -35,6 +35,10 @@ public class CarouselView: UIScrollView {
     }
     public var selectedCallback: ((currentPage: Int) -> ())?
     
+    private var canInfinite: Bool {
+        return isInfinite && views.count > 1
+    }
+    
     private enum ScrollDirection {
         case None
         case Top
@@ -95,6 +99,7 @@ public class CarouselView: UIScrollView {
         
         // Check condition with tracking for only prepare view when still scrolling.
         if keyPath == "contentOffset" && isInfinite && self.tracking {
+        if keyPath == "contentOffset" && canInfinite && self.tracking {
             guard let change = change, let oldOffset = change[NSKeyValueChangeOldKey]?.CGPointValue() else {
                 return
             }

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -125,11 +125,46 @@ public class CarouselView: UIScrollView {
     }
     
     private func prepareViewForInfiniteInlusion(direction: ScrollDirection) {
+        let viewsCount = CGFloat(views.count)
+        
         switch direction {
         case .Left:
-            print("Left")
+            if self.contentOffset.x <= self.bounds.size.width {
+                guard let lastView = views.last else {
+                    return
+                }
+                
+                lastView.frame = CGRect(x: 0, y: 0, width: self.bounds.size.width, height: self.bounds.size.height)
+                
+            } else if self.contentOffset.x >= viewsCount * self.bounds.size.width {
+                guard let firstView = views.first else {
+                    return
+                }
+                
+                firstView.frame = CGRect(x: (viewsCount + 1) * self.bounds.size.width, y: 0, width: self.bounds.size.width, height: self.bounds.size.height)
+                
+            } else {
+                resetInfiniteContentShift()
+            }
+
         case .Right:
-            print("Right")
+            if self.contentOffset.x >= viewsCount * self.bounds.size.width {
+                guard let firstView = views.first else {
+                    return
+                }
+                
+                firstView.frame = CGRect(x: (viewsCount + 1) * self.bounds.size.width, y: 0, width: self.bounds.size.width, height: self.bounds.size.height)
+                
+            } else if self.contentOffset.x <= self.bounds.size.width {
+                guard let lastView = views.last else {
+                    return
+                }
+                
+                lastView.frame = CGRect(x: 0, y: 0, width: self.bounds.size.width, height: self.bounds.size.height)
+                
+            } else {
+                resetInfiniteContentShift()
+            }
         case .Top:
             break
         case .Down:

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -193,7 +193,7 @@ public class CarouselView: UIScrollView {
             resetInfiniteContentShift()
             
         } else if self.contentOffset.x >= (viewsCount + 1) * self.bounds.size.width {
-            self.contentOffset = CGPointMake(self.bounds.size.width, 0)
+            self.contentOffset = CGPoint(x: self.bounds.size.width, y: 0)
             
             resetInfiniteContentShift()
         }

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -95,8 +95,9 @@ public class CarouselView: UIScrollView {
     // MARK: - KVO Delegate
     override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
         
-        if keyPath == "contentOffset" && isInfinite {
-            guard let change = change, let oldOffset = change[NSKeyValueChangeOldKey] as? CGPoint else {
+        // Check condition with tracking for only prepare view when still scrolling.
+        if keyPath == "contentOffset" && isInfinite && self.tracking {
+            guard let change = change, let oldOffset = change[NSKeyValueChangeOldKey]?.CGPointValue() else {
                 return
             }
             
@@ -104,8 +105,6 @@ public class CarouselView: UIScrollView {
             
             prepareViewForInfiniteInlusion(ScrollDirection(fromPoint: oldOffset, toPoint: newOffset))
             
-        } else {
-            super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
         }
     }
     
@@ -121,7 +120,18 @@ public class CarouselView: UIScrollView {
     }
     
     private func prepareViewForInfiniteInlusion(direction: ScrollDirection) {
-        
+        switch direction {
+        case .Left:
+            print("Left")
+        case .Right:
+            print("Right")
+        case .Top:
+            break
+        case .Down:
+            break
+        default:
+            break
+        }
     }
 }
 

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -12,6 +12,32 @@ public class CarouselView: UIScrollView {
     @IBOutlet weak var pageControl: UIPageControl?
     @IBOutlet public var views: [UIView] = []
     
+    enum ScrollDirection {
+        case None
+        case Top
+        case Right
+        case Down
+        case Left
+        
+        init(fromPoint: CGPoint, toPoint: CGPoint) {
+            if fromPoint.x - toPoint.x < 0 && fromPoint.y == toPoint.y {
+                self = .Left
+                
+            } else if fromPoint.x - toPoint.x > 0 && fromPoint.y == toPoint.y {
+                self = .Right
+                
+            } else if fromPoint.x == toPoint.x && fromPoint.y - toPoint.y < 0 {
+                self = .Down
+                
+            } else if fromPoint.x == toPoint.x && fromPoint.y - toPoint.y > 0 {
+                self = .Top
+                
+            } else {
+                self = .None
+            }
+        }
+    }
+    
     public var currentPage: Int {
         set {
             switch pageControl {
@@ -45,6 +71,10 @@ public class CarouselView: UIScrollView {
         self.configure()
     }
     
+    deinit {
+        self.removeObserver(self, forKeyPath: "contentOffset")
+    }
+    
     override public func drawRect(rect: CGRect) {
         views
             .enumerate()
@@ -60,6 +90,15 @@ public class CarouselView: UIScrollView {
         self.contentSize = CGSize(width: CGFloat(views.count) * self.bounds.width, height: self.bounds.height)
     }
     
+    // MARK: - KVO Delegate
+    override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+        if keyPath == "contentOffset" {
+            
+        } else {
+            super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
+        }
+    }
+    
     // MARK: - Private Methods
     private func configure() {
         self.delegate = self
@@ -67,9 +106,12 @@ public class CarouselView: UIScrollView {
         self.showsVerticalScrollIndicator = false
         self.showsHorizontalScrollIndicator = false
         self.scrollsToTop = false
+        
+        self.addObserver(self, forKeyPath: "contentOffset", options: .Old, context: nil)
     }
 }
 
+// MARK: - ScrollViewDelegate
 extension CarouselView: UIScrollViewDelegate {
     public func scrollViewDidScroll(scrollView: UIScrollView) {
         let remainder: CGFloat = scrollView.contentOffset.x % self.bounds.width

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -101,7 +101,6 @@ public class CarouselView: UIScrollView {
     override public func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
         
         // Check condition with tracking for only prepare view when still scrolling.
-        if keyPath == "contentOffset" && isInfinite && self.tracking {
         if keyPath == "contentOffset" && canInfinite && self.tracking {
             guard let change = change, let oldOffset = change[NSKeyValueChangeOldKey]?.CGPointValue() else {
                 return

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -204,7 +204,27 @@ public class CarouselView: UIScrollView {
 // MARK: - ScrollViewDelegate
 extension CarouselView: UIScrollViewDelegate {
     public func scrollViewDidScroll(scrollView: UIScrollView) {
-        let remainder: CGFloat = scrollView.contentOffset.x % self.bounds.width
-        currentPage = Int(scrollView.contentOffset.x / self.bounds.size.width + ((remainder > self.bounds.size.width / 2) ? 1 : 0))
+        let offsetX: Int = Int(scrollView.contentOffset.x)
+        let width: Int = Int(self.bounds.width)
+        
+        let remainder: Int = offsetX % width
+        var page: Int = offsetX / width + ((remainder > width / 2) ? 1 : 0)
+        
+        if canInfinite {
+            if page == 0 {
+                page = views.count - 1
+                
+            } else if page == views.count + 1 {
+                page = 0
+                
+            } else {
+                page = page - 1
+            }
+            
+            shiftToRealViewPosition()
+        }
+        
+        currentPage = page
+    }
     }
 }

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -226,5 +226,10 @@ extension CarouselView: UIScrollViewDelegate {
         
         currentPage = page
     }
+    
+    public func scrollViewDidEndDecelerating(scrollView: UIScrollView) {
+        if canInfinite {
+            resetInfiniteContentShift()
+        }
     }
 }

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -12,7 +12,30 @@ public class CarouselView: UIScrollView {
     @IBOutlet weak var pageControl: UIPageControl?
     @IBOutlet public var views: [UIView] = []
     
-    enum ScrollDirection {
+    @IBInspectable public var isInfinite: Bool = false
+    
+    public var currentPage: Int {
+        set {
+            switch pageControl {
+            case .None:
+                self.currentPage = newValue
+            case .Some(let pageControl):
+                pageControl.currentPage = newValue
+            }
+        }
+        
+        get {
+            switch pageControl {
+            case .None:
+                return self.currentPage
+            case .Some(let pageControl):
+                return pageControl.currentPage
+            }
+        }
+    }
+    public var selectedCallback: ((currentPage: Int) -> ())?
+    
+    private enum ScrollDirection {
         case None
         case Top
         case Right
@@ -37,27 +60,6 @@ public class CarouselView: UIScrollView {
             }
         }
     }
-    
-    public var currentPage: Int {
-        set {
-            switch pageControl {
-            case .None:
-                self.currentPage = newValue
-            case .Some(let pageControl):
-                pageControl.currentPage = newValue
-            }
-        }
-        
-        get {
-            switch pageControl {
-            case .None:
-                return self.currentPage
-            case .Some(let pageControl):
-                return pageControl.currentPage
-            }
-        }
-    }
-    public var selectedCallback: ((currentPage: Int) -> ())?
 
     override public init(frame: CGRect) {
         super.init(frame: frame)

--- a/CHCarouselView/Views/CarouselView.swift
+++ b/CHCarouselView/Views/CarouselView.swift
@@ -91,7 +91,10 @@ public class CarouselView: UIScrollView {
         
         pageControl?.numberOfPages = views.count
         
-        self.contentSize = CGSize(width: CGFloat(views.count) * self.bounds.width, height: self.bounds.height)
+        let viewsCountWithInfiniteMock = (canInfinite ? 2 : 0) + views.count
+        
+        self.contentSize = CGSize(width: CGFloat(viewsCountWithInfiniteMock) * self.bounds.width, height: self.bounds.height)
+        self.contentOffset = canInfinite ? CGPoint(x: self.bounds.width, y: 0) : CGPointZero
     }
     
     // MARK: - KVO Delegate


### PR DESCRIPTION
Implemented infinite scroll carousel by shifting view to prefix position and suffix position.
If we want to make the scroll view can infinite scroll illusion, we have to prepare N + 2 components, one for first, another for last.
When scroll the first, automatically move to the N - 1 position and if scroll to last, move to 1 position.
However, there is no perfect way to copy view to fill the first position and the last.
(If take the view's snapshot, UIImageView's image download from network will leave view blank.)
So, I decide to move the component instead of prepare a same view.
This decision bring the side effect is when scroll too fast, it probably leave blank space.
